### PR TITLE
Feature/disconnected

### DIFF
--- a/collector/catalog.yml
+++ b/collector/catalog.yml
@@ -26,7 +26,7 @@
       shell:
         chdir: '{{ local_tmp }}/operators'
         cmd: |
-          opm index prune --tag {{ index_image_out }} --packages {{ operator_list }} --from-index {{ opm_index_image }}
+          opm index prune --tag {{ index_image_out }} --packages {{ operator_list }} --from-index {{ opm_index_image }} --binary-image {{ opm_index_image }}
 
     - name: '{{ ansible_name_module }} | command:cmd | Push Custom Catalog {{ index_image_out }}'
       shell:

--- a/collector/tools/run.sh
+++ b/collector/tools/run.sh
@@ -20,6 +20,7 @@ podman run -it --rm \
     --name ${project} -h ${project}                \
     --volume  $(pwd):/root/koffer:z                \
     --volume  ${HOME}/bundle:/root/bundle:z        \
+    --volume  ${HOME}/operators:/root/operators:z  \
     --volume  /tmp/koffer/.docker:/root/.docker:z  \
     --entrypoint ./collector/site.yml              \
   quay.io/cloudctl/koffer:extra

--- a/collector/vars/global.yml
+++ b/collector/vars/global.yml
@@ -1,5 +1,6 @@
 ---
 target: "{{ lookup('env', 'TARGET') }}"                    ## fqdn: 'registry.my.company.net:5000' default: 'localhost:5000' koffer internal listener
+target_namespace: "{{ lookup('env', 'TARGET_NAMESPACE') }}"                    ## registry ns: 'registry.my.company.net:5000/namespace' default: 'redhat'
 WallE: "{{ lookup('env', 'WALLE') | default(false) }}"   ## boolean: 'true|false|nill'
 bundle: "{{ lookup('env', 'BUNDLE') | default(false) }}" ## boolean: 'true|false|nill'
 mirror: "{{ lookup('env', 'MIRROR') | default(false) }}" ## boolean: 'true|false|nill'
@@ -15,7 +16,8 @@ default_index_name: 'redhat/redhat-operator-index:v4.6'
 default_index_image: 'registry.redhat.io/{{ default_index_name }}'
 
 target_registry: "{{ target | default('localhost:5000', true) }}"
-index_image_out: '{{ target_registry }}/redhat/custom-{{ index_name }}:{{ index_tag }}'
+target_registry_namespace: "{{ target_namespace | default('redhat', true) }}"
+index_image_out: '{{ target_registry }}/{{target_registry_namespace}}/custom-{{ index_name }}:{{ index_tag }}'
 
 opm_index_list: '{{ operator_list | default(default_operator_list, true) }}'
 opm_index_image: '{{ index_image | default(default_index_image, true) }}'


### PR DESCRIPTION
Adding base binary image to build the custom image from in the opm command. This will help to reuse the base image that is already inside a private repository.

Adding the option to give custom registry namespaces, it will default to redhat. 